### PR TITLE
Replace parameters by options

### DIFF
--- a/baremaps-benchmarks/src/main/java/com/baremaps/TileReaderBenchmark.java
+++ b/baremaps-benchmarks/src/main/java/com/baremaps/TileReaderBenchmark.java
@@ -4,8 +4,8 @@ import com.baremaps.core.postgis.PostgisHelper;
 import com.baremaps.tiles.Tile;
 import com.baremaps.tiles.TileReader;
 import com.baremaps.tiles.config.Config;
-import com.baremaps.tiles.postgis.SimpleTileReader;
-import com.baremaps.tiles.postgis.WithTileReader;
+import com.baremaps.tiles.postgis.SlowTileReader;
+import com.baremaps.tiles.postgis.FastTileReader;
 import com.baremaps.tiles.util.TileUtil;
 import java.io.File;
 import java.io.FileInputStream;
@@ -53,7 +53,7 @@ public class TileReaderBenchmark {
   @Warmup(iterations = 1)
   @Measurement(iterations = 2)
   public void basic() throws SQLException, ParseException {
-    reader = new SimpleTileReader(datasource, config);
+    reader = new SlowTileReader(datasource, config);
     execute();
   }
 
@@ -62,7 +62,7 @@ public class TileReaderBenchmark {
   @Warmup(iterations = 1)
   @Measurement(iterations = 2)
   public void with() throws SQLException, ParseException {
-    reader = new WithTileReader(datasource, config);
+    reader = new FastTileReader(datasource, config);
     execute();
   }
 

--- a/baremaps-cli/src/main/java/com/baremaps/cli/Baremaps.java
+++ b/baremaps-cli/src/main/java/com/baremaps/cli/Baremaps.java
@@ -9,12 +9,15 @@ import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(subcommands = {
-    Import.class,
-    Update.class,
-    Export.class,
-    Serve.class,
-}, name = "baremaps")
+@Command(
+    name = "baremaps",
+    description = "A toolkit for producing vector tiles.",
+    subcommands = {
+        Import.class,
+        Update.class,
+        Export.class,
+        Serve.class,
+    })
 public class Baremaps implements Callable<Integer> {
 
   @Override
@@ -25,6 +28,7 @@ public class Baremaps implements Callable<Integer> {
 
   public static void main(String[] args) {
     CommandLine cmd = new CommandLine(new Baremaps())
+        .setUsageHelpLongOptionsMaxWidth(30)
         .addMixin("logging", new Mixins());
     cmd.execute(args);
   }

--- a/baremaps-cli/src/main/java/com/baremaps/cli/commands/Mixins.java
+++ b/baremaps-cli/src/main/java/com/baremaps/cli/commands/Mixins.java
@@ -4,7 +4,10 @@ import picocli.CommandLine.Option;
 
 public class Mixins {
 
-  @Option(names = { "--level" }, description = { "The log level." })
+  @Option(
+      names = { "--level" },
+      paramLabel= "LEVEL",
+      description = { "The log level." })
   protected String level = "INFO";
 
 }

--- a/baremaps-cli/src/main/java/com/baremaps/cli/options/TileReaderOption.java
+++ b/baremaps-cli/src/main/java/com/baremaps/cli/options/TileReaderOption.java
@@ -1,0 +1,8 @@
+package com.baremaps.cli.options;
+
+import com.baremaps.tiles.TileReader;
+import com.baremaps.tiles.postgis.FastTileReader;
+
+public enum TileReaderOption {
+  slow, fast
+}

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/postgis/FastTileReader.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/postgis/FastTileReader.java
@@ -18,7 +18,7 @@ import org.apache.commons.dbcp2.PoolingDataSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class WithTileReader extends AbstractTileReader {
+public class FastTileReader extends AbstractTileReader {
 
   private static Logger logger = LogManager.getLogger();
 
@@ -45,7 +45,7 @@ public class WithTileReader extends AbstractTileReader {
 
   private final Map<Layer, List<Query>> queries;
 
-  public WithTileReader(PoolingDataSource datasource, Config config) {
+  public FastTileReader(PoolingDataSource datasource, Config config) {
     this.datasource = datasource;
     this.config = config;
     this.queries = config.getLayers().stream()

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/postgis/SlowTileReader.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/postgis/SlowTileReader.java
@@ -17,7 +17,7 @@ import org.apache.commons.dbcp2.PoolingDataSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class SimpleTileReader extends AbstractTileReader {
+public class SlowTileReader extends AbstractTileReader {
 
   private static Logger logger = LogManager.getLogger();
 
@@ -41,7 +41,7 @@ public class SimpleTileReader extends AbstractTileReader {
 
   private final Config config;
 
-  public SimpleTileReader(PoolingDataSource datasource, Config config) {
+  public SlowTileReader(PoolingDataSource datasource, Config config) {
     this.datasource = datasource;
     this.config = config;
   }

--- a/examples/contour/README.md
+++ b/examples/contour/README.md
@@ -44,11 +44,10 @@ To preview the data, run the tile server with the following command:
 
 ```bash
 baremaps serve \
-  'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps' \
-  'config.yaml' \
-  'static/'
+  --database 'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps' \
+  --config 'config.yaml' \
+  --assets 'static/'
 ```
-
 
 ## Alternative
 

--- a/examples/naturalearth/README.md
+++ b/examples/naturalearth/README.md
@@ -55,7 +55,7 @@ To preview the data, run the tile server with the following command:
 
 ```bash
 baremaps serve \
-  'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps' \
-  'config.yaml' \
-  'static/'
+  --database 'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps' \
+  --config 'config.yaml' \
+  --assets 'static/'
 ```

--- a/examples/openstreetmap/README.md
+++ b/examples/openstreetmap/README.md
@@ -5,18 +5,18 @@ You can import the OSM data in postgis using the following command:
 
 ```bash
 baremaps import \
-  'examples/openstreetmap/liechtenstein-latest.osm.pbf' \
-  'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps'
+  --input 'liechtenstein-latest.osm.pbf' \
+  --database 'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps'
 ```
 
 To preview the data, start the tile server:
 
 ```bash
 baremaps serve \
-  'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps' \
-  'examples/openstreetmap/config.yaml' \
-  'examples/openstreetmap/static/' \
-  --tile-reader with
+  --database 'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps' \
+  --config 'config.yaml' \
+  --assets 'static/' \
+  --reader fast
 ```
 
 Well done, the tile server should have started and a map of liechtenstein should appear in your browser ([http://localhost:9000/](http://localhost:8082/))!
@@ -25,9 +25,10 @@ Vector tiles are rarely served dynamically in production. The following command 
 
 ```bash
 baremaps export \
-  'examples/openstreetmap/config.yaml' \
-  'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps' \
-  'examples/openstreetmap/tiles/' \
+  --database 'jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps' \
+  --config 'config.yaml' \
+  --repository 'tiles/' \
   --minZoom 14 \
-  --maxZoom 14
+  --maxZoom 14 \
+  --reader fast
 ```


### PR DESCRIPTION
Commands often have more than two parameters. Using options make the commands more explicit.