### PR TITLE
Add batch parameters and improve config accordingly

### DIFF
--- a/baremaps-benchmarks/src/main/java/com/baremaps/TileReaderBenchmark.java
+++ b/baremaps-benchmarks/src/main/java/com/baremaps/TileReaderBenchmark.java
@@ -16,6 +16,7 @@ package com.baremaps;
 
 import com.baremaps.tiles.TileStore;
 import com.baremaps.tiles.config.Config;
+import com.baremaps.tiles.config.ConfigConstructor;
 import com.baremaps.tiles.database.FastPostgisTileStore;
 import com.baremaps.tiles.database.SlowPostgisTileStore;
 import com.baremaps.tiles.util.TileUtil;
@@ -58,7 +59,7 @@ public class TileReaderBenchmark {
   public void prepare() throws IOException, ClassNotFoundException {
     Class.forName("org.postgresql.Driver");
     try (FileInputStream fis = new FileInputStream(new File("./examples/openstreetmap/config.yaml"))) {
-      Yaml yaml = new Yaml(new Constructor(Config.class));
+      Yaml yaml = new Yaml(new ConfigConstructor());
       config = yaml.load(fis);
       datasource = PostgisHelper.poolingDataSource(
           "jdbc:postgresql://localhost:5432/baremaps?allowMultiQueries=true&user=baremaps&password=baremaps");

--- a/baremaps-cli/src/main/java/com/baremaps/cli/blueprint/BlueprintBuilder.java
+++ b/baremaps-cli/src/main/java/com/baremaps/cli/blueprint/BlueprintBuilder.java
@@ -42,8 +42,11 @@ public class BlueprintBuilder {
     map.put("sources", ImmutableSortedMap.naturalOrder()
         .put("baremaps", ImmutableSortedMap.naturalOrder()
             .put("type", "vector")
-            .put("minzoom", config.getMinZoom())
-            .put("maxzoom", config.getMaxZoom())
+            .put("minzoom", config.getBounds().getMinZoom())
+            .put("maxzoom", config.getBounds().getMaxZoom())
+            .put("bounds", new double[] {
+                config.getBounds().getMinLon(), config.getBounds().getMinLat(),
+                config.getBounds().getMaxLon(), config.getBounds().getMaxLat()})
             .put("tiles", Arrays.asList(String.format("http://%s:%s/tiles/{z}/{x}/{y}.pbf",
                 config.getHost(),
                 config.getPort())))

--- a/baremaps-cli/src/main/java/com/baremaps/cli/blueprint/ConfigFormatter.java
+++ b/baremaps-cli/src/main/java/com/baremaps/cli/blueprint/ConfigFormatter.java
@@ -35,15 +35,15 @@ public class ConfigFormatter {
     map.put("id", config.getId());
     map.put("host", config.getHost());
     map.put("port", config.getPort());
-    map.put("lon", config.getLon());
-    map.put("lat", config.getLat());
-    map.put("zoom", config.getZoom());
-    map.put("minZoom", config.getMinZoom());
-    map.put("maxZoom", config.getMaxZoom());
-    map.put("bearing", config.getBearing());
-    map.put("pitch", config.getPitch());
+
+    // Group the properties used by the blueprint
+    map.put("center", config.getCenter());
+    map.put("bounds", config.getBounds());
+
+    // Put the nested properties at the end
     map.put("layers", formatLayers(config.getLayers()));
     map.put("styles", formatStyles(config.getStyles()));
+
     return map;
   }
 

--- a/baremaps-cli/src/main/java/com/baremaps/cli/command/Update.java
+++ b/baremaps-cli/src/main/java/com/baremaps/cli/command/Update.java
@@ -130,11 +130,11 @@ public class Update implements Callable<Integer> {
     FileSystem fileSystem = mixins.fileSystem();
 
     logger.info("Downloading changes.");
-    String changePath = changePath(nextSequenceNumber);
+    String changePath =  path(nextSequenceNumber) + ".osc.gz";
     URI changeURI = new URI(String.format("%s/%s", input, changePath));
 
     logger.info("Downloading state information.");
-    String statePath = statePath(nextSequenceNumber);
+    String statePath = path(nextSequenceNumber) + ".state.txt";;
     URI stateURI = new URI(String.format("%s/%s", input, statePath));
 
     ProjectionTransformer projectionTransformer = new ProjectionTransformer(coordinateTransformFactory
@@ -152,7 +152,7 @@ public class Update implements Callable<Integer> {
     logger.info("Saving differences.");
     try (PrintWriter diffPrintWriter = new PrintWriter(fileSystem.write(delta))) {
       for (Tile tile : deltaMaker.getTiles()) {
-        diffPrintWriter.println(String.format("%d/%d/%d", tile.getX(), tile.getY(), tile.getZ()));
+        diffPrintWriter.println(String.format("%d/%d/%d", tile.x(), tile.y(), tile.z()));
       }
     }
 
@@ -187,14 +187,5 @@ public class Update implements Callable<Integer> {
         + leading.substring(3, 6) + "/"
         + leading.substring(6, 9);
   }
-
-  public String changePath(long sequenceNumber) {
-    return path(sequenceNumber) + ".osc.gz";
-  }
-
-  public String statePath(long sequenceNumber) {
-    return path(sequenceNumber) + ".state.txt";
-  }
-
 
 }

--- a/baremaps-cli/src/main/java/com/baremaps/cli/handler/BlueprintHandler.java
+++ b/baremaps-cli/src/main/java/com/baremaps/cli/handler/BlueprintHandler.java
@@ -1,5 +1,5 @@
-package com.baremaps.cli.handler;/*
- * Copyright (C) 2020 The baremaps Authors
+/*
+ * Copyright (C) 2020 The Baremaps Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@ package com.baremaps.cli.handler;/*
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.baremaps.cli.handler;
 
 import static com.google.common.net.HttpHeaders.CONTENT_ENCODING;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
@@ -46,13 +47,13 @@ public class BlueprintHandler implements HttpHandler {
       String template = Resources.toString(url, Charsets.UTF_8);
 
       ImmutableMap<String, Object> params = ImmutableMap.<String, Object>builder()
-          .put("lon", config.getLon())
-          .put("lat", config.getLat())
-          .put("zoom", config.getZoom())
-          .put("bearing", config.getBearing())
-          .put("pitch", config.getPitch())
-          .put("minZoom", config.getMinZoom())
-          .put("maxZoom", config.getMaxZoom())
+          .put("lon", config.getCenter().getLon())
+          .put("lat", config.getCenter().getLat())
+          .put("zoom", config.getCenter().getZoom())
+          .put("bearing", config.getCenter().getBearing())
+          .put("pitch", config.getCenter().getPitch())
+          .put("minZoom", config.getBounds().getMinZoom())
+          .put("maxZoom", config.getBounds().getMaxZoom())
           .build();
       String result = TemplateFormatter.format(template, params);
       byte[] bytes = result.getBytes(Charsets.UTF_8);

--- a/baremaps-cli/src/main/java/com/baremaps/cli/handler/ConfigHandler.java
+++ b/baremaps-cli/src/main/java/com/baremaps/cli/handler/ConfigHandler.java
@@ -18,6 +18,7 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 
 import com.baremaps.cli.blueprint.ConfigFormatter;
 import com.baremaps.tiles.config.Config;
+import com.baremaps.tiles.config.ConfigConstructor;
 import com.google.common.base.Charsets;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -48,7 +49,7 @@ public class ConfigHandler implements HttpHandler {
       ConfigFormatter configBuilder = new ConfigFormatter(this.config);
       Map<String, Object> config = configBuilder.format();
 
-      Constructor constructor = new Constructor(Config.class);
+      Constructor constructor = new ConfigConstructor();
       Representer representer = new Representer();
       DumperOptions options = new DumperOptions();
       options.setDefaultFlowStyle(FlowStyle.BLOCK);

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/config/Bounds.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/config/Bounds.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 The Baremaps Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.baremaps.tiles.config;
+
+public class Bounds {
+
+  private double minLon = -180;
+
+  private double maxLon = 180;
+
+  private double minLat = -85.05113;
+
+  private double maxLat = 85.05113;
+
+  private double minZoom = 0;
+
+  private double maxZoom = 22;
+
+  public double getMinLon() {
+    return minLon;
+  }
+
+  public void setMinLon(double minLon) {
+    this.minLon = minLon;
+  }
+
+  public double getMaxLon() {
+    return maxLon;
+  }
+
+  public void setMaxLon(double maxLon) {
+    this.maxLon = maxLon;
+  }
+
+  public double getMinLat() {
+    return minLat;
+  }
+
+  public void setMinLat(double minLat) {
+    this.minLat = minLat;
+  }
+
+  public double getMaxLat() {
+    return maxLat;
+  }
+
+  public void setMaxLat(double maxLat) {
+    this.maxLat = maxLat;
+  }
+
+  public double getMinZoom() {
+    return minZoom;
+  }
+
+  public void setMinZoom(double minZoom) {
+    this.minZoom = minZoom;
+  }
+
+  public double getMaxZoom() {
+    return maxZoom;
+  }
+
+  public void setMaxZoom(double maxZoom) {
+    this.maxZoom = maxZoom;
+  }
+
+}

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/config/Center.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/config/Center.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 The Baremaps Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.baremaps.tiles.config;
+
+public class Center {
+
+  private double lon = 0;
+
+  private double lat = 0;
+
+  private double zoom = 0;
+
+  private double bearing = 0;
+
+  private double pitch = 0;
+
+  public double getLon() {
+    return lon;
+  }
+
+  public void setLon(double lon) {
+    this.lon = lon;
+  }
+
+  public double getLat() {
+    return lat;
+  }
+
+  public void setLat(double lat) {
+    this.lat = lat;
+  }
+
+  public double getZoom() {
+    return zoom;
+  }
+
+  public void setZoom(double zoom) {
+    this.zoom = zoom;
+  }
+
+  public double getBearing() {
+    return bearing;
+  }
+
+  public void setBearing(double bearing) {
+    this.bearing = bearing;
+  }
+
+  public double getPitch() {
+    return pitch;
+  }
+
+  public void setPitch(double pitch) {
+    this.pitch = pitch;
+  }
+
+}

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/config/Config.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/config/Config.java
@@ -14,6 +14,7 @@
 
 package com.baremaps.tiles.config;
 
+import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Map;
 
@@ -25,24 +26,13 @@ public class Config {
 
   private int port = 9000;
 
-  private double lon = 0;
+  private Center center = new Center();
 
-  private double lat = 0;
+  private Bounds bounds = new Bounds();
 
-  private double zoom = 0;
+  private List<Layer> layers = Lists.newArrayList();
 
-  private double minZoom = 0;
-
-  private double maxZoom = 22;
-
-  private double bearing = 0;
-
-  private double pitch = 0;
-
-  private List<Layer> layers;
-
-  private List<Map<String, Object>> styles;
-
+  private List<Map<String, Object>> styles = Lists.newArrayList();
 
   public String getId() {
     return id;
@@ -68,60 +58,20 @@ public class Config {
     this.port = port;
   }
 
-  public double getLon() {
-    return lon;
+  public Bounds getBounds() {
+    return bounds;
   }
 
-  public void setLon(double lon) {
-    this.lon = lon;
+  public void setBounds(Bounds bounds) {
+    this.bounds = bounds;
   }
 
-  public double getLat() {
-    return lat;
+  public Center getCenter() {
+    return center;
   }
 
-  public void setLat(double lat) {
-    this.lat = lat;
-  }
-
-  public double getZoom() {
-    return zoom;
-  }
-
-  public void setZoom(double zoom) {
-    this.zoom = zoom;
-  }
-
-  public double getMinZoom() {
-    return minZoom;
-  }
-
-  public void setMinZoom(double minZoom) {
-    this.minZoom = minZoom;
-  }
-
-  public double getMaxZoom() {
-    return maxZoom;
-  }
-
-  public void setMaxZoom(double maxZoom) {
-    this.maxZoom = maxZoom;
-  }
-
-  public double getBearing() {
-    return bearing;
-  }
-
-  public void setBearing(double bearing) {
-    this.bearing = bearing;
-  }
-
-  public double getPitch() {
-    return pitch;
-  }
-
-  public void setPitch(double pitch) {
-    this.pitch = pitch;
+  public void setCenter(Center center) {
+    this.center = center;
   }
 
   public List<Layer> getLayers() {

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/config/ConfigConstructor.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/config/ConfigConstructor.java
@@ -11,19 +11,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.baremaps.tiles.config;
 
-package com.baremaps.cli.blueprint;
+import org.yaml.snakeyaml.constructor.AbstractConstruct;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.Tag;
 
-import java.util.Map;
+public class ConfigConstructor extends Constructor {
 
-public class TemplateFormatter {
-
-  public static String format(String template, Map<String, Object> params) {
-    String result = template;
-    for (String key : params.keySet()) {
-      result = result.replace(String.format("{%s}", key), params.get(key).toString());
-    }
-    return result;
+  public ConfigConstructor() {
+    super(Config.class);
+    this.yamlConstructors.put(Tag.NULL, new AbstractConstruct() {
+      @Override
+      public Object construct(Node node) {
+        return new Config();
+      }
+    });
   }
 
 }

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/database/FastPostgisTileStore.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/database/FastPostgisTileStore.java
@@ -27,13 +27,11 @@ import java.sql.Statement;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.dbcp2.PoolingDataSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.locationtech.jts.geom.Envelope;
 
 public class FastPostgisTileStore extends PostgisTileStore {
 
@@ -103,7 +101,7 @@ public class FastPostgisTileStore extends PostgisTileStore {
   private String query(Tile tile) {
     String sources = queries.entrySet().stream()
         .filter(
-            entry -> entry.getKey().getMinZoom() <= tile.getZ() &&  tile.getZ() < entry.getKey().getMaxZoom())
+            entry -> entry.getKey().getMinZoom() <= tile.z() &&  tile.z() < entry.getKey().getMaxZoom())
         .flatMap(entry -> entry.getValue().stream().map(query -> MessageFormat.format(SOURCE,
             query.getSource(),
             query.getId(),
@@ -116,7 +114,7 @@ public class FastPostgisTileStore extends PostgisTileStore {
         .collect(Collectors.joining(COMMA));
     String targets = queries.entrySet().stream()
         .filter(entry ->
-            entry.getKey().getMinZoom() <= tile.getZ() &&  tile.getZ() < entry.getKey().getMaxZoom())
+            entry.getKey().getMinZoom() <= tile.z() &&  tile.z() < entry.getKey().getMaxZoom())
         .map(entry -> {
           String queries = entry.getValue().stream()
               .map(select -> {

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/database/SlowPostgisTileStore.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/database/SlowPostgisTileStore.java
@@ -68,7 +68,7 @@ public class SlowPostgisTileStore extends PostgisTileStore {
       int length = 0;
       GZIPOutputStream gzip = new GZIPOutputStream(data);
       for (Layer layer : config.getLayers()) {
-        if (layer.getMinZoom() <= tile.getZ() && tile.getZ() < layer.getMaxZoom()) {
+        if (layer.getMinZoom() <= tile.z() && tile.z() < layer.getMaxZoom()) {
           String sql = query(tile, layer);
           logger.debug("Executing tile query: {}", sql);
           try (Statement statement = connection.createStatement()) {

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/mbtiles/MBTilesUtil.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/mbtiles/MBTilesUtil.java
@@ -86,9 +86,9 @@ public final class MBTilesUtil {
   private static PreparedStatement readTileStatement(Connection connection, Tile tile)
       throws SQLException {
     PreparedStatement statement = connection.prepareStatement(SELECT_TILE);
-    statement.setInt(1, tile.getZ());
-    statement.setInt(2, tile.getX());
-    statement.setInt(3, reverseY(tile.getY(), tile.getZ()));
+    statement.setInt(1, tile.z());
+    statement.setInt(2, tile.x());
+    statement.setInt(3, reverseY(tile.y(), tile.z()));
     return statement;
   }
 
@@ -111,9 +111,9 @@ public final class MBTilesUtil {
 
   public static void writeTile(Connection connection, Tile tile, byte[] bytes) throws SQLException {
     try (PreparedStatement statement = connection.prepareStatement(INSERT_TILE)) {
-      statement.setInt(1, tile.getZ());
-      statement.setInt(2, tile.getX());
-      statement.setInt(3, reverseY(tile.getY(), tile.getZ()));
+      statement.setInt(1, tile.z());
+      statement.setInt(2, tile.x());
+      statement.setInt(3, reverseY(tile.y(), tile.z()));
       statement.setBytes(4, bytes);
       statement.executeUpdate();
     }
@@ -121,9 +121,9 @@ public final class MBTilesUtil {
 
   public static void deleteTile(Connection connection, Tile tile) throws SQLException {
     try (PreparedStatement statement = connection.prepareStatement(DELETE_TILE)) {
-      statement.setInt(1, tile.getZ());
-      statement.setInt(2, tile.getX());
-      statement.setInt(3, reverseY(tile.getY(), tile.getZ()));
+      statement.setInt(1, tile.z());
+      statement.setInt(2, tile.x());
+      statement.setInt(3, reverseY(tile.y(), tile.z()));
       statement.execute();
     }
   }

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/store/FileSystemTileStore.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/store/FileSystemTileStore.java
@@ -47,7 +47,7 @@ public class FileSystemTileStore implements TileStore {
   }
 
   public URI getURI(Tile tile) {
-    return uri.resolve(String.format("%s/%s/%s.pbf", tile.getZ(), tile.getX(), tile.getY()));
+    return uri.resolve(String.format("%s/%s/%s.pbf", tile.z(), tile.x(), tile.y()));
   }
 
 }

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/stream/BatchFilter.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/stream/BatchFilter.java
@@ -11,19 +11,25 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.baremaps.tiles.stream;
 
-package com.baremaps.cli.blueprint;
+import com.baremaps.util.tile.Tile;
+import java.util.function.Predicate;
 
-import java.util.Map;
+public class BatchFilter implements Predicate<Tile> {
 
-public class TemplateFormatter {
+  private final int batchArraySize;
 
-  public static String format(String template, Map<String, Object> params) {
-    String result = template;
-    for (String key : params.keySet()) {
-      result = result.replace(String.format("{%s}", key), params.get(key).toString());
-    }
-    return result;
+  private final int batchArrayIndex;
+
+  public BatchFilter(int batchArraySize, int batchArrayIndex) {
+    this.batchArraySize = batchArraySize;
+    this.batchArrayIndex = batchArrayIndex;
+  }
+
+  @Override
+  public boolean test(Tile tile) {
+    return batchArraySize <= 1 || tile.index() % batchArraySize == batchArrayIndex;
   }
 
 }

--- a/baremaps-tiles/src/main/java/com/baremaps/tiles/stream/TileHandler.java
+++ b/baremaps-tiles/src/main/java/com/baremaps/tiles/stream/TileHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 The baremaps Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.baremaps.tiles.stream;
+
+import com.baremaps.tiles.TileStore;
+import com.baremaps.util.tile.Tile;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+public class TileHandler implements Consumer<Tile> {
+
+  public final TileStore tileSource;
+
+  public final TileStore tileTarget;
+
+  public TileHandler(TileStore tileSource, TileStore tileTarget) {
+    this.tileSource = tileSource;
+    this.tileTarget = tileTarget;
+  }
+
+  @Override
+  public void accept(Tile tile) {
+    try {
+      byte[] bytes = tileSource.read(tile);
+      if (bytes != null) {
+        tileTarget.write(tile, bytes);
+      } else {
+        tileTarget.delete(tile);
+      }
+    } catch (IOException ex) {
+      throw new RuntimeException("An error occurred while creating the tiles", ex);
+    }
+  }
+
+}

--- a/baremaps-tiles/src/test/java/com/baremaps/tiles/config/ConfigTest.java
+++ b/baremaps-tiles/src/test/java/com/baremaps/tiles/config/ConfigTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 The Baremaps Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.baremaps.tiles.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+class ConfigTest {
+
+  @Test
+  public void loadEmptyYamlConfig() {
+    Yaml yaml = new Yaml(new ConfigConstructor());
+    Config config = yaml.load("");
+    assertNotNull(config);
+    assertEquals(config.getId(), "baremaps");
+  }
+
+  @Test
+  public void loadYamlConfig() {
+    Yaml yaml = new Yaml(new ConfigConstructor());
+    Config config = yaml.load("id: test");
+    assertNotNull(config);
+    assertEquals(config.getId(), "test");
+  }
+
+  @Test
+  public void checkOverrideBehavior() {
+    Yaml yaml = new Yaml(new ConfigConstructor());
+    Config config = yaml.load("{id: test, center: {lon: 10}}");
+    assertNotNull(config);
+    assertEquals(config.getId(), "test");
+    assertEquals(config.getCenter().getLon(), 10);
+    assertEquals(config.getCenter().getLat(), 0);
+  }
+
+}

--- a/baremaps-tiles/src/test/java/com/baremaps/tiles/postgis/ConfigTest.java
+++ b/baremaps-tiles/src/test/java/com/baremaps/tiles/postgis/ConfigTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.baremaps.tiles.config.Config;
+import com.baremaps.tiles.config.ConfigConstructor;
 import java.io.InputStream;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
@@ -28,9 +29,10 @@ public class ConfigTest {
   @Test
   public void load() {
     InputStream input = this.getClass().getClassLoader().getResourceAsStream("config.yaml");
-    Yaml yaml = new Yaml(new Constructor(Config.class));
+    Yaml yaml = new Yaml(new ConfigConstructor());
     Config config = yaml.load(input);
     assertNotNull(config);
     assertTrue(config.getLayers().size() == 2);
   }
+
 }

--- a/baremaps-tiles/src/test/java/com/baremaps/tiles/stream/BatchFilterTest.java
+++ b/baremaps-tiles/src/test/java/com/baremaps/tiles/stream/BatchFilterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 The baremaps Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.baremaps.tiles.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.baremaps.util.tile.Tile;
+import com.google.common.math.IntMath;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class BatchFilterTest {
+
+  @Test
+  void testFiltering() {
+    // Compute all the tiles for zoom levels 0 to 3
+    final int streamSize = 85;
+    final List<Tile> tiles = new ArrayList<>();
+    for (int z = 0; z <= 3; z++) {
+      for (int x = 0; x < IntMath.pow(2, z); x++) {
+        for (int y = 0; y < IntMath.pow(2, z); y++) {
+          tiles.add(new Tile(x, y, z));
+        }
+      }
+    }
+    assertEquals(streamSize, tiles.size());
+
+    // ensures that the batches have the correct size and retain de correct tiles
+    final int batchArraySize = 5;
+    for (int batchArrayIndex = 0; batchArrayIndex < batchArraySize; batchArrayIndex++) {
+      List<Tile> batch = tiles.stream()
+          .filter(new BatchFilter(batchArraySize, batchArrayIndex))
+          .sorted(Comparator.comparingLong(Tile::index))
+          .collect(Collectors.toList());
+      assertEquals(streamSize / batchArraySize, batch.size());
+      int tileIndex = batchArrayIndex;
+      for (Tile tile : batch) {
+        assertEquals(tileIndex, tile.index());
+        tileIndex += batchArraySize;
+      }
+    }
+  }
+}

--- a/baremaps-util/src/main/java/com/baremaps/util/fs/LocalFileSystem.java
+++ b/baremaps-util/src/main/java/com/baremaps/util/fs/LocalFileSystem.java
@@ -61,7 +61,7 @@ public class LocalFileSystem extends FileSystem {
 
   @Override
   public void delete(URI uri) throws IOException {
-    Files.delete(Paths.get(uri.getPath()));
+    Files.deleteIfExists(Paths.get(uri.getPath()));
   }
 
 }

--- a/baremaps-util/src/test/java/com/baremaps/util/tile/TileTest.java
+++ b/baremaps-util/src/test/java/com/baremaps/util/tile/TileTest.java
@@ -22,7 +22,7 @@ class TileTest {
   void getTile() {
     double lon = 1062451.988597151, lat = 5965417.348546229;
     int z = 14;
-    Tile tile = Tile.getTile(lon, lat, 14);
+    Tile tile = Tile.fromLonLat(lon, lat, 14);
     int y = (int) ((1 - Math.log(Math.tan(Math.toRadians(lat)) + 1 / Math.cos(Math.toRadians(lat)))
         / Math.PI) / 2.0 * (1 << z));
   }

--- a/examples/buildings/config.yaml
+++ b/examples/buildings/config.yaml
@@ -1,13 +1,19 @@
 id: openstreetmap
 host: localhost
 port: 9000
-lon: 9.5554
-lat: 47.166
-zoom: 15.0
-minZoom: 12
-maxZoom: 20
-bearing: 0.0
-pitch: 0.0
+center:
+  lon: 0.1278
+  lat: 51.5074
+  zoom: 15.0
+  bearing: 0.0
+  pitch: 0.0
+bounds:
+  minLon: -0.511482
+  maxLon: 0.335437
+  minLat: 51.28554
+  maxLat: 51.69344
+  minZoom: 12
+  maxZoom: 20
 layers:
 - id: aerialway
   type: geometry

--- a/examples/contour/config.yaml
+++ b/examples/contour/config.yaml
@@ -1,9 +1,15 @@
 id: 'contour'
-lon: 9.5554
-lat: 47.1660
-zoom: 14
-minZoom: 12
-maxZoom: 20
+center:
+  lon: 9.5554
+  lat: 47.1660
+  zoom: 14
+bounds:
+  minLon: 9.471078
+  maxLon: 9.636217
+  minLat: 47.04774
+  maxLat: 47.27128
+  minZoom: 12
+  maxZoom: 20
 layers:
   - id: 'aster_dem'
     type: 'geometry'

--- a/examples/naturalearth/config.yaml
+++ b/examples/naturalearth/config.yaml
@@ -1,9 +1,4 @@
 id: 'naturalearth'
-lon: 0
-lat: 0
-zoom: 1
-minZoom: 0
-maxZoom: 12
 layers:
   - id: 'ne_110m_admin_0_boundary_lines_land'
     type: geometry

--- a/examples/openstreetmap/config.yaml
+++ b/examples/openstreetmap/config.yaml
@@ -1,9 +1,15 @@
 id: 'openstreetmap'
-lon: 9.5554
-lat: 47.1660
-zoom: 15
-minZoom: 12
-maxZoom: 20
+center:
+  lon: 9.5554
+  lat: 47.1660
+  zoom: 15
+bounds:
+  minLon: 9.471078
+  maxLon: 9.636217
+  minLat: 47.04774
+  maxLat: 47.27128
+  minZoom: 12
+  maxZoom: 16
 layers:
   - id: 'aeroway'
     type: 'geometry'


### PR DESCRIPTION
The batch parameters enables baremap to integrate with AWS Batch (#62). As a result, the generation of tiles can be parallelized and distributed.

As the extent of the map is needed to list its tiles, the configuration files now contain bounding information. This is preferable than using the OSM headers because baremaps is supposed to work with different datasets.