### PR TITLE
Improve error message for malformed queries (#181)

### DIFF
--- a/baremaps-tile-postgres/src/main/java/com/baremaps/tile/postgres/PostgisQueryParser.java
+++ b/baremaps-tile-postgres/src/main/java/com/baremaps/tile/postgres/PostgisQueryParser.java
@@ -36,7 +36,7 @@ public class PostgisQueryParser {
   }
 
   public static Parse parse(Layer layer, Query query) {
-    String sql = query.getSql().replaceAll("\\s+"," ").trim();
+    String sql = query.getSql().replaceAll("\\s+", " ").trim();
     Matcher matcher = QUERY_PATTERN.matcher(sql);
 
     if (!matcher.matches()) {
@@ -49,7 +49,10 @@ public class PostgisQueryParser {
 
     List<String> columns = split(select);
     if (columns.size() != 3) {
-      throw new IllegalArgumentException("The SQL query malformed");
+      String message = String.format("The layer '%s' contains a malformed query.\n"
+          + "\tExpected format:\n\t\tSELECT c1::bigint, c2::hstore, c3::geometry FROM t WHERE c\n"
+          + "\tActual query:\n\t\t%s", layer.getId(), sql);
+      throw new IllegalArgumentException(message);
     }
 
     String id = column(columns.get(0));


### PR DESCRIPTION
@nicolas-heigvd I missunderstood your point regarding the error messages when reading your description of the issue, sorry. I think this new error message will greatly improve the situation. It displays the affected layer, the expected format for a query and the actual query. The error message now looks like this:

```
java.lang.IllegalArgumentException: The layer 'aerialway' contains a malformed query.
	Expected format:
		SELECT c1::bigint, c2::hstore, c3::geometry FROM t WHERE c
	Actual query:
		SELECT id, tags FROM osm_ways_z${zoom} WHERE tags ? 'aerialway'
	at com.baremaps.tile.postgres.PostgisQueryParser.parse(PostgisQueryParser.java:55) ~[classes/:?]
	at com.baremaps.tile.postgres.PostgisTileStore.lambda$null$0(PostgisTileStore.java:137) ~[classes/:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1621) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
```