### PR TITLE
Improve the creation of geometries for relations

### DIFF
--- a/baremaps-osm/src/main/java/com/baremaps/osm/geometry/GeometryHandler.java
+++ b/baremaps-osm/src/main/java/com/baremaps/osm/geometry/GeometryHandler.java
@@ -11,13 +11,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.CoordinateList;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
-import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.operation.polygonize.Polygonizer;
 import org.slf4j.Logger;
@@ -72,9 +68,9 @@ public class GeometryHandler implements ElementHandler {
       return;
     }
 
-    // Collect the polygons of the relation
-    Polygon[] members = relation.getMembers().stream()
-        .filter(member -> "outer".equals(member.getRole()) || "inner".equals(member.getRole()))
+    // Collect the members of the relation
+    List<LineString> members = relation.getMembers()
+        .stream()
         .map(member -> {
           try {
             return referenceCache.get(member.getRef());
@@ -83,28 +79,32 @@ public class GeometryHandler implements ElementHandler {
           }
         })
         .filter(Objects::nonNull)
-        .map(references -> {
+        .map(reference -> {
           try {
-            Coordinate[] coordinateArray = coordinateCache.get(references).stream()
+            return coordinateCache.get(reference).stream()
                 .filter(Objects::nonNull)
                 .toArray(Coordinate[]::new);
-            CoordinateList coordinateList = new CoordinateList(coordinateArray);
-            coordinateList.closeRing();
-            return geometryFactory.createPolygon(coordinateList.toCoordinateArray());
           } catch (CacheException e) {
             return null;
           }
         })
-        .filter(Objects::nonNull)
-        .toArray(Polygon[]::new);
+        .filter(t -> t != null)
+        .map(t -> geometryFactory.createLineString(t))
+        .collect(Collectors.toList());
 
-    if (members.length == 1) {
-      relation.setGeometry(members[0]);
+    // Check whether the relation contains members
+    if (members.isEmpty()) {
+      return;
     }
 
-    if (members.length > 1) {
-      MultiPolygon multiPolygon = geometryFactory.createMultiPolygon(members);
-      relation.setGeometry(multiPolygon);
+    // Try to create the polygon from the members
+    try {
+      Polygonizer polygonizer = new Polygonizer(true);
+      polygonizer.add(members);
+      relation.setGeometry(polygonizer.getGeometry());
+    } catch (Exception e) {
+      logger.warn("Unable to build the geometry for relation " + relation.getId(), e);
+      return;
     }
   }
 }


### PR DESCRIPTION
The creation of geometries is now timing out after one second and a warning is printed in the logs. For instance, complex relations such as coastlines can be ignored. In a future release the timeout should become configurable and some relations may be ignored explicitely.