### PR TITLE
Add missing deps (baremaps-tile) in openapi

### DIFF
--- a/baremaps-openapi/pom.xml
+++ b/baremaps-openapi/pom.xml
@@ -59,6 +59,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.baremaps</groupId>
+      <artifactId>baremaps-tile</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.servicetalk</groupId>
       <artifactId>servicetalk-data-jackson</artifactId>
     </dependency>


### PR DESCRIPTION
My IDE was complaining about missing deps. 