### PR TITLE
add: request filter to decorate the URI BaseUri

### DIFF
--- a/baremaps-ogcapi/pom.xml
+++ b/baremaps-ogcapi/pom.xml
@@ -95,7 +95,6 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
@@ -108,6 +107,10 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.parser.v3</groupId>
+      <artifactId>swagger-parser</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -134,28 +137,19 @@
       <groupId>org.postgresql</groupId>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.containers</groupId>
-      <artifactId>jersey-container-grizzly2-http</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.test-framework</groupId>
       <artifactId>jersey-test-framework-util</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-inmemory</artifactId>
+      <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.jsqlparser</groupId>
-      <artifactId>jsqlparser</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.swagger.parser.v3</groupId>
-      <artifactId>swagger-parser</artifactId>
-      <version>2.0.24</version>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/BaseUriRequestFilter.java
+++ b/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/BaseUriRequestFilter.java
@@ -15,13 +15,12 @@
 package com.baremaps.ogcapi;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import javax.inject.Singleton;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
-import javax.ws.rs.core.*;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.Provider;
 
 @Provider
@@ -32,22 +31,16 @@ public class BaseUriRequestFilter implements ContainerRequestFilter {
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
     UriBuilder baseUri = UriBuilder.fromUri(requestContext.getUriInfo().getBaseUri());
-
-    MultivaluedMap headers = requestContext.getHeaders();
-
+    MultivaluedMap<String, String> headers = requestContext.getHeaders();
     if (headers.get("X-Forwarded-Proto") != null) {
-      baseUri.scheme(headers.getFirst("X-Forwarded-Proto").toString());
+      baseUri.scheme(headers.getFirst("X-Forwarded-Proto"));
     }
     if (headers.get("X-Forwarded-Host") != null) {
-      baseUri.host(headers.getFirst("X-Forwarded-Host").toString());
+      baseUri.host(headers.getFirst("X-Forwarded-Host"));
     }
     if (headers.get("X-Forwarded-Port") != null) {
-      baseUri.port(Integer.parseInt((String) headers.getFirst("X-Forwarded-Port")));
+      baseUri.port(Integer.parseInt(headers.getFirst("X-Forwarded-Port")));
     }
-    try {
-      requestContext.setRequestUri(baseUri.build(), new URI("https://dsdfasf.ch/"));
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-    }
+    requestContext.setRequestUri(baseUri.build(), requestContext.getUriInfo().getRequestUri());
   }
 }

--- a/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/BaseUriRequestFilter.java
+++ b/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/BaseUriRequestFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 The Baremaps Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.baremaps.ogcapi;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.inject.Singleton;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.*;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@PreMatching
+@Singleton
+public class BaseUriRequestFilter implements ContainerRequestFilter {
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    UriBuilder baseUri = UriBuilder.fromUri(requestContext.getUriInfo().getBaseUri());
+
+    MultivaluedMap headers = requestContext.getHeaders();
+
+    if (headers.get("X-Forwarded-Proto") != null) {
+      baseUri.scheme(headers.getFirst("X-Forwarded-Proto").toString());
+    }
+    if (headers.get("X-Forwarded-Host") != null) {
+      baseUri.host(headers.getFirst("X-Forwarded-Host").toString());
+    }
+    if (headers.get("X-Forwarded-Port") != null) {
+      baseUri.port(Integer.parseInt((String) headers.getFirst("X-Forwarded-Port")));
+    }
+    try {
+      requestContext.setRequestUri(baseUri.build(), new URI("https://dsdfasf.ch/"));
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/resources/RootResource.java
+++ b/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/resources/RootResource.java
@@ -51,6 +51,11 @@ public class RootResource implements DefaultApi {
                         .type("application/json")
                         .rel("service-desc"),
                     new Link()
+                        .title("API description")
+                        .href(address + "api")
+                        .type("application/yaml")
+                        .rel("service-desc"),
+                    new Link()
                         .title("API documentation")
                         .href(address + "swagger")
                         .type("text/html")

--- a/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/resources/RootResource.java
+++ b/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/resources/RootResource.java
@@ -18,14 +18,17 @@ import com.baremaps.api.DefaultApi;
 import com.baremaps.model.LandingPage;
 import com.baremaps.model.Link;
 import java.util.Arrays;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 public class RootResource implements DefaultApi {
 
+  @Context UriInfo uriInfo;
+
   @Override
   public Response getLandingPage() {
-    String address = "localhost:8080";
-
+    String address = uriInfo.getBaseUri().toString();
     LandingPage landingPage =
         new LandingPage()
             .title("Baremaps")
@@ -34,27 +37,22 @@ public class RootResource implements DefaultApi {
                 Arrays.asList(
                     new Link()
                         .title("This document (landing page)")
-                        .href(String.format("http://%s/", address))
+                        .href(address)
                         .type("application/json")
                         .rel("self"),
                     new Link()
                         .title("Conformance declaration")
-                        .href(String.format("http://%s/conformance", address))
+                        .href(address + "conformance")
                         .type("application/json")
                         .rel("conformance"),
                     new Link()
                         .title("API description")
-                        .href(String.format("http://%s/api", address))
+                        .href(address + "api")
                         .type("application/json")
                         .rel("service-desc"),
                     new Link()
-                        .title("API description")
-                        .href(String.format("http://%s/api", address))
-                        .type("application/yaml")
-                        .rel("service-desc"),
-                    new Link()
                         .title("API documentation")
-                        .href(String.format("http://%s/swagger", address))
+                        .href(address + "swagger")
                         .type("text/html")
                         .rel("service-doc")));
     return Response.ok().entity(landingPage).build();

--- a/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/resources/StylesResource.java
+++ b/baremaps-ogcapi/src/main/java/com/baremaps/ogcapi/resources/StylesResource.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.inject.Inject;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.json.Json;
@@ -35,6 +37,8 @@ public class StylesResource implements StylesApi {
       QualifiedType.of(MbStyle.class).with(Json.class);
 
   private final Jdbi jdbi;
+
+  @Context UriInfo uriInfo;
 
   @Inject
   public StylesResource(Jdbi jdbi) {
@@ -84,11 +88,10 @@ public class StylesResource implements StylesApi {
     StyleSet styleSet = new StyleSet();
     List<StyleSetEntry> entries = new ArrayList<>();
 
+    String address = uriInfo.getRequestUri().toString();
     for (UUID id : ids) {
       Link link = new Link();
-      link.setHref(
-          "http://localhost:8080/styles/"
-              + id); // TODO: set dynamically from server or where the server gets it from
+      link.setHref(address + id);
       link.setType("application/vnd.mapbox.style+json");
       link.setRel("stylesheet");
 

--- a/baremaps-ogcapi/src/test/java/com/baremaps/ogcapi/BaseUriRequestFilterTest.java
+++ b/baremaps-ogcapi/src/test/java/com/baremaps/ogcapi/BaseUriRequestFilterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 The Baremaps Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.baremaps.ogcapi;
+
+import static org.junit.Assert.assertEquals;
+
+import com.baremaps.ogcapi.BaseUriRequestFilter;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+
+public class BaseUriRequestFilterTest extends JerseyTest {
+  @Path("")
+  public static class BaseUriService {
+    @GET
+    public String getBaseUri(@Context UriInfo uriInfo) {
+      return uriInfo.getBaseUri().toString();
+    }
+  }
+
+  @Override
+  protected ResourceConfig configure() {
+    enable(TestProperties.LOG_TRAFFIC);
+    enable(TestProperties.DUMP_ENTITY);
+    return new ResourceConfig(BaseUriRequestFilter.class, BaseUriService.class);
+  }
+
+  @org.junit.Test
+  public void testBaseUri() {
+
+    String baseUriStr =
+        target()
+            .path("")
+            .request()
+            .header("X-Forwarded-Host", "test.com")
+            .header("X-Forwarded-Proto", "https")
+            .header("X-Forwarded-Port", "443")
+            .get(String.class);
+    assertEquals("https://test.com:443/", baseUriStr);
+  }
+}

--- a/baremaps-ogcapi/src/test/java/com/baremaps/ogcapi/BaseUriRequestFilterTest.java
+++ b/baremaps-ogcapi/src/test/java/com/baremaps/ogcapi/BaseUriRequestFilterTest.java
@@ -16,7 +16,6 @@ package com.baremaps.ogcapi;
 
 import static org.junit.Assert.assertEquals;
 
-import com.baremaps.ogcapi.BaseUriRequestFilter;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
@@ -26,6 +25,7 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 
 public class BaseUriRequestFilterTest extends JerseyTest {
+
   @Path("")
   public static class BaseUriService {
     @GET
@@ -38,12 +38,11 @@ public class BaseUriRequestFilterTest extends JerseyTest {
   protected ResourceConfig configure() {
     enable(TestProperties.LOG_TRAFFIC);
     enable(TestProperties.DUMP_ENTITY);
-    return new ResourceConfig(BaseUriRequestFilter.class, BaseUriService.class);
+    return new ResourceConfig().registerClasses(BaseUriRequestFilter.class, BaseUriService.class);
   }
 
   @org.junit.Test
   public void testBaseUri() {
-
     String baseUriStr =
         target()
             .path("")

--- a/baremaps-osm-postgres/src/main/java/com/baremaps/osm/postgres/PostgresHeaderTable.java
+++ b/baremaps-osm-postgres/src/main/java/com/baremaps/osm/postgres/PostgresHeaderTable.java
@@ -129,13 +129,14 @@ public class PostgresHeaderTable implements HeaderTable {
   public List<Header> selectAll() throws DatabaseException {
     try (Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(selectLatest)) {
-      ResultSet result = statement.executeQuery();
-      List<Header> entities = new ArrayList<>();
-      while (result.next()) {
-        Header entity = getEntity(result);
-        entities.add(entity);
+      try (ResultSet result = statement.executeQuery()) {
+        List<Header> entities = new ArrayList<>();
+        while (result.next()) {
+          Header entity = getEntity(result);
+          entities.add(entity);
+        }
+        return entities;
       }
-      return entities;
     } catch (SQLException e) {
       throw new DatabaseException(e);
     }
@@ -151,11 +152,12 @@ public class PostgresHeaderTable implements HeaderTable {
     try (Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(select)) {
       statement.setObject(1, id);
-      ResultSet result = statement.executeQuery();
-      if (result.next()) {
-        return getEntity(result);
-      } else {
-        return null;
+      try (ResultSet result = statement.executeQuery()) {
+        if (result.next()) {
+          return getEntity(result);
+        } else {
+          return null;
+        }
       }
     } catch (SQLException e) {
       throw new DatabaseException(e);
@@ -170,13 +172,14 @@ public class PostgresHeaderTable implements HeaderTable {
     try (Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(selectIn)) {
       statement.setArray(1, connection.createArrayOf("int8", ids.toArray()));
-      ResultSet result = statement.executeQuery();
-      Map<Long, Header> entities = new HashMap<>();
-      while (result.next()) {
-        Header entity = getEntity(result);
-        entities.put(entity.getReplicationSequenceNumber(), entity);
+      try (ResultSet result = statement.executeQuery()) {
+        Map<Long, Header> entities = new HashMap<>();
+        while (result.next()) {
+          Header entity = getEntity(result);
+          entities.put(entity.getReplicationSequenceNumber(), entity);
+        }
+        return ids.stream().map(entities::get).collect(Collectors.toList());
       }
-      return ids.stream().map(entities::get).collect(Collectors.toList());
     } catch (SQLException e) {
       throw new DatabaseException(e);
     }

--- a/baremaps-osm-postgres/src/main/java/com/baremaps/osm/postgres/PostgresNodeTable.java
+++ b/baremaps-osm-postgres/src/main/java/com/baremaps/osm/postgres/PostgresNodeTable.java
@@ -146,11 +146,12 @@ public class PostgresNodeTable implements NodeTable {
     try (Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(select)) {
       statement.setObject(1, id);
-      ResultSet result = statement.executeQuery();
-      if (result.next()) {
-        return getEntity(result);
-      } else {
-        return null;
+      try (ResultSet result = statement.executeQuery()) {
+        if (result.next()) {
+          return getEntity(result);
+        } else {
+          return null;
+        }
       }
     } catch (SQLException e) {
       throw new DatabaseException(e);
@@ -164,13 +165,14 @@ public class PostgresNodeTable implements NodeTable {
     try (Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(selectIn)) {
       statement.setArray(1, connection.createArrayOf("int8", ids.toArray()));
-      ResultSet result = statement.executeQuery();
-      Map<Long, Node> entities = new HashMap<>();
-      while (result.next()) {
-        Node entity = getEntity(result);
-        entities.put(entity.getId(), entity);
+      try (ResultSet result = statement.executeQuery()) {
+        Map<Long, Node> entities = new HashMap<>();
+        while (result.next()) {
+          Node entity = getEntity(result);
+          entities.put(entity.getId(), entity);
+        }
+        return ids.stream().map(entities::get).collect(Collectors.toList());
       }
-      return ids.stream().map(entities::get).collect(Collectors.toList());
     } catch (SQLException e) {
       throw new DatabaseException(e);
     }

--- a/baremaps-osm-postgres/src/test/java/com/baremaps/osm/postgres/PostgresNodeTableTest.java
+++ b/baremaps-osm-postgres/src/test/java/com/baremaps/osm/postgres/PostgresNodeTableTest.java
@@ -43,7 +43,7 @@ class PostgresNodeTableTest {
   PostgresNodeTable nodeStore;
 
   @BeforeEach
-  void createTable() throws SQLException, IOException {
+  void beforeEach() throws SQLException, IOException {
     dataSource = PostgresUtils.datasource(DATABASE_URL);
     nodeStore = new PostgresNodeTable(dataSource);
     try (Connection connection = dataSource.getConnection()) {

--- a/baremaps-postgres/pom.xml
+++ b/baremaps-postgres/pom.xml
@@ -23,10 +23,6 @@
       <artifactId>jdbi3-jpa</artifactId>
     </dependency>
     <dependency>
-      <artifactId>jts-core</artifactId>
-      <groupId>org.locationtech.jts</groupId>
-    </dependency>
-    <dependency>
       <artifactId>postgresql</artifactId>
       <groupId>org.postgresql</groupId>
     </dependency>
@@ -35,8 +31,9 @@
       <artifactId>baremaps-osm</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-dbcp2</artifactId>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>5.0.0</version>
     </dependency>
   </dependencies>
 

--- a/baremaps-postgres/src/main/java/com/baremaps/postgres/jdbc/PostgresUtils.java
+++ b/baremaps-postgres/src/main/java/com/baremaps/postgres/jdbc/PostgresUtils.java
@@ -15,6 +15,8 @@
 package com.baremaps.postgres.jdbc;
 
 import com.google.common.io.Resources;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -22,16 +24,23 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import javax.sql.DataSource;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public final class PostgresUtils {
 
   private PostgresUtils() {}
 
   public static DataSource datasource(String url) {
-    BasicDataSource datasource = new BasicDataSource();
-    datasource.setUrl(url);
-    return datasource;
+    return datasource(url, Runtime.getRuntime().availableProcessors());
+  }
+
+  public static DataSource datasource(String url, int poolSize) {
+    if (poolSize < 1) {
+      throw new IllegalArgumentException("PoolSize cannot be inferior to 1");
+    }
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(url);
+    config.setMaximumPoolSize(poolSize);
+    return new HikariDataSource(config);
   }
 
   public static void executeResource(Connection connection, String resource)

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <version.lib.mockito>1.10.19</version.lib.mockito>
     <version.lib.servlet>3.1.0</version.lib.servlet>
     <version.lib.activation>1.1.1</version.lib.activation>
+    <version.lib.swagger-parser>2.0.24</version.lib.swagger-parser>
   </properties>
 
   <modules>
@@ -540,6 +541,11 @@
         <version>${version.lib.swagger}</version>
       </dependency>
       <dependency>
+        <groupId>io.swagger.parser.v3</groupId>
+        <artifactId>swagger-parser</artifactId>
+        <version>${version.lib.swagger-parser}</version>
+      </dependency>
+      <dependency>
         <groupId>javax.validation</groupId>
         <artifactId>validation-api</artifactId>
         <version>${version.lib.validation}</version>
@@ -703,6 +709,12 @@
         <artifactId>mockito-all</artifactId>
         <version>${version.lib.mockito}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <scope>test</scope>
+        <version>${version.lib.junit-vintage}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR adds a request filter that is responsible of decorating the baseUri of the request.

It can be used from any class with

```java
public class MyNewClass implements SomeApi {
 @Context UriInfo uriInfo;

  @Override
  public Response myResponse() {
    String address = uriInfo.getBaseUri().toString();
    etc
```


in the current implementation, it supports the following http headers:
- X-Forwarded-Port
- X-Forwarded-Proto
- X-Forwarded-Host

If one or more of these headers are present, they will override the current base URI.

Here is an example:

```bash
curl -H "X-Forwarded-Host: coucou.ch" -H "X-Forwarded-Port: 443" -H "X-Forwarded-Proto: https" localhost:8000 | jq ''
```

result:
```json
{
  "title": "Baremaps",
  "description": "Baremaps OGC API Landing Page",
  "links": [
    {
      "href": "https://coucou.ch:443/",
      "rel": "self",
      "type": "application/json",
      "title": "This document (landing page)"
    },
    {
      "href": "https://coucou.ch:443/conformance",
      "rel": "conformance",
      "type": "application/json",
      "title": "Conformance declaration"
    },
    {
      "href": "https://coucou.ch:443/api",
      "rel": "service-desc",
      "type": "application/json",
      "title": "API description"
    },
    {
      "href": "https://coucou.ch:443/swagger",
      "rel": "service-doc",
      "type": "text/html",
      "title": "API documentation"
    }
  ]
}
```

This PR invalidates this other PR: https://github.com/baremaps/baremaps/pull/340