### PR TITLE
Add a country code to the geocoder request

### DIFF
--- a/baremaps-geocoder/src/main/java/com/baremaps/geocoder/Request.java
+++ b/baremaps-geocoder/src/main/java/com/baremaps/geocoder/Request.java
@@ -17,16 +17,28 @@ package com.baremaps.geocoder;
 public class Request {
 
   private final String query;
+  private final String countryCode;
 
   private final int limit;
 
   public Request(String query, int limit) {
     this.query = query;
     this.limit = limit;
+    this.countryCode = null;
+  }
+
+  public Request(String query, int limit, String countryCode) {
+    this.query = query;
+    this.limit = limit;
+    this.countryCode = countryCode;
   }
 
   public String query() {
     return query;
+  }
+
+  public String countryCode() {
+    return countryCode;
   }
 
   public int limit() {

--- a/baremaps-geocoder/src/main/java/com/baremaps/geocoder/geonames/GeonamesGeocoder.java
+++ b/baremaps-geocoder/src/main/java/com/baremaps/geocoder/geonames/GeonamesGeocoder.java
@@ -33,12 +33,14 @@ import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 
 public class GeonamesGeocoder extends Geocoder {
 
@@ -117,7 +119,9 @@ public class GeonamesGeocoder extends Geocoder {
     BooleanQuery.Builder builder = new Builder();
     builder.add(new QueryParser("name", analyzer).parse(request.query()), Occur.SHOULD);
     builder.add(new QueryParser("country", analyzer).parse(request.query()), Occur.SHOULD);
-    builder.add(new QueryParser("countryCode", analyzer).parse(request.query()), Occur.SHOULD);
+    if(request.countryCode() != null){
+        builder.add(new TermQuery(new Term("countryCode", request.countryCode())), Occur.MUST);
+    }
     return builder.build();
   }
 }

--- a/baremaps-geocoder/src/test/java/com/baremaps/geocoder/geonames/GeonamesGeocoderTest.java
+++ b/baremaps-geocoder/src/test/java/com/baremaps/geocoder/geonames/GeonamesGeocoderTest.java
@@ -46,4 +46,31 @@ class GeonamesGeocoderTest {
 
     Files.walk(path).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
   }
+
+  @Test
+  public void buildAndSearchWithTheRightCountryCode() throws IOException, URISyntaxException, ParseException {
+    Path path = Files.createTempDirectory(Paths.get("."), "geocoder_");
+    URI data = Resources.getResource("LI.txt").toURI();
+    Geocoder geocoder = new GeonamesGeocoder(path, data);
+    geocoder.build();
+
+    Response response = geocoder.search(new Request("Bim Alta Schloss", 10, "LI"));
+    assertEquals(10, response.results().size());
+    assertEquals("Bim Alta Schloss", response.results().get(0).document().get("name"));
+
+    Files.walk(path).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+  }
+
+  @Test
+  public void buildAndSearchWithTheWrongCountryCode() throws IOException, URISyntaxException, ParseException {
+    Path path = Files.createTempDirectory(Paths.get("."), "geocoder_");
+    URI data = Resources.getResource("LI.txt").toURI();
+    Geocoder geocoder = new GeonamesGeocoder(path, data);
+    geocoder.build();
+
+    Response response = geocoder.search(new Request("Bim Alta Schloss", 10, "CH"));
+    assertEquals(0, response.results().size());
+
+    Files.walk(path).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+  }
 }


### PR DESCRIPTION
I have a few questions : 

- Should the country code be an enum instead of a string within the Request object?
- Should we validate that the country code is in the [isoCountries map](https://github.com/baremaps/baremaps/blob/2347ec27bd215f58995273c84bd85373cba6d22e/baremaps-geocoder/src/main/java/com/baremaps/geocoder/IsoCountriesUtils.java)
- Should the country code should a java Optional instead of being "nullable"?
- Should I use a specific naming convention for my unit tests?