### PR TITLE
Share datasources between workflow tasks

### DIFF
--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/database/ExecuteSql.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/database/ExecuteSql.java
@@ -17,6 +17,7 @@ package org.apache.baremaps.cli.database;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import org.apache.baremaps.cli.Options;
+import org.apache.baremaps.workflow.WorkflowContext;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -42,7 +43,7 @@ public class ExecuteSql implements Callable<Integer> {
   @Override
   public Integer call() throws Exception {
     new org.apache.baremaps.workflow.tasks.ExecuteSql(database, file.toAbsolutePath().toString(),
-        parallel).run();
+        parallel).execute(new WorkflowContext());
     return 0;
   }
 }

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/database/ImportOpenStreetMap.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/database/ImportOpenStreetMap.java
@@ -17,6 +17,7 @@ package org.apache.baremaps.cli.database;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import org.apache.baremaps.cli.Options;
+import org.apache.baremaps.workflow.WorkflowContext;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -42,7 +43,7 @@ public class ImportOpenStreetMap implements Callable<Integer> {
   @Override
   public Integer call() throws Exception {
     new org.apache.baremaps.workflow.tasks.ImportOpenStreetMap(file.toAbsolutePath().toString(),
-        database, srid).run();
+        database, srid).execute(new WorkflowContext());
     return 0;
   }
 }

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/database/UpdateOpenStreetMap.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/database/UpdateOpenStreetMap.java
@@ -16,6 +16,7 @@ package org.apache.baremaps.cli.database;
 
 import java.util.concurrent.Callable;
 import org.apache.baremaps.cli.Options;
+import org.apache.baremaps.workflow.WorkflowContext;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -36,7 +37,8 @@ public class UpdateOpenStreetMap implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    new org.apache.baremaps.workflow.tasks.UpdateOpenStreetMap(database, srid).run();
+    new org.apache.baremaps.workflow.tasks.UpdateOpenStreetMap(database, srid)
+        .execute(new WorkflowContext());
     return 0;
   }
 }

--- a/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Export.java
+++ b/baremaps-cli/src/main/java/org/apache/baremaps/cli/map/Export.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import org.apache.baremaps.cli.Options;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.apache.baremaps.workflow.tasks.ExportVectorTiles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,8 @@ public class Export implements Callable<Integer> {
   @Override
   public Integer call() throws Exception {
     new ExportVectorTiles(database, tileset.toAbsolutePath().toString(),
-        repository.toAbsolutePath().toString(), batchArraySize, batchArrayIndex, mbtiles).run();
+        repository.toAbsolutePath().toString(), batchArraySize, batchArrayIndex, mbtiles)
+            .execute(new WorkflowContext());
     return 0;
   }
 }

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Step.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Step.java
@@ -14,4 +14,11 @@ package org.apache.baremaps.workflow;
 
 import java.util.List;
 
+/**
+ * A step is a group of tasks executed sequentially.
+ *
+ * @param id the identifier of the step
+ * @param needs the identifiers of the steps that must be executed before this step
+ * @param tasks the tasks of the step
+ */
 public record Step(String id, List<String> needs, List<Task> tasks) {}

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Step.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Step.java
@@ -15,7 +15,8 @@ package org.apache.baremaps.workflow;
 import java.util.List;
 
 /**
- * A step is a group of tasks executed sequentially.
+ * A step is a group of tasks executed sequentially in a workflow.
+ * A step may depend on other steps through the needs attribute.
  *
  * @param id the identifier of the step
  * @param needs the identifiers of the steps that must be executed before this step

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Task.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Task.java
@@ -19,8 +19,19 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+/**
+ * A task is a unit of work in a workflow.
+ */
 @JsonSerialize
 @JsonTypeInfo(use = Id.CLASS, property = "type")
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-public interface Task extends Runnable {
+public interface Task {
+
+  /**
+   * Executes the task.
+   *
+   * @throws Exception if an error occurs during the execution of the task
+   */
+  void execute(WorkflowContext context) throws Exception;
+
 }

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Workflow.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Workflow.java
@@ -16,7 +16,9 @@ import java.util.List;
 
 /**
  * A workflow is a graph of steps that can be executed in parallel.
+ * Steps are nodes of a directed acyclic graph (DAG) and each step may depend on other steps through the needs attribute.
+ * The directed acyclic graph is built, validated and executed by the {@link WorkflowExecutor}.
  *
- * @param steps
+ * @param steps the steps of the workflow
  */
 public record Workflow(List<Step> steps) {}

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Workflow.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/Workflow.java
@@ -14,4 +14,9 @@ package org.apache.baremaps.workflow;
 
 import java.util.List;
 
+/**
+ * A workflow is a graph of steps that can be executed in parallel.
+ *
+ * @param steps
+ */
 public record Workflow(List<Step> steps) {}

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/WorkflowContext.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/WorkflowContext.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.baremaps.workflow;
+
+
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.sql.DataSource;
+import org.apache.baremaps.postgres.PostgresUtils;
+
+/**
+ * A context that is passed to the tasks of a workflow and used to share data between tasks.
+ */
+public class WorkflowContext {
+
+  private Map<String, DataSource> dataSources = new ConcurrentHashMap<>() {};
+
+  /**
+   * Returns the data source associated with the specified database.
+   *
+   * @param database the JDBC connection string to the database
+   * @return the data source
+   */
+  public DataSource getDataSource(String database) {
+    return dataSources.computeIfAbsent(database, d -> PostgresUtils.dataSource(d));
+  }
+
+}

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/DownloadUrl.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/DownloadUrl.java
@@ -13,6 +13,7 @@
 package org.apache.baremaps.workflow.tasks;
 
 import org.apache.baremaps.workflow.Task;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.apache.baremaps.workflow.WorkflowException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -26,16 +27,13 @@ public record DownloadUrl(String url, String path) implements Task {
   private static final Logger logger = LoggerFactory.getLogger(DownloadUrl.class);
 
   @Override
-  public void run() {
+  public void execute(WorkflowContext context) throws Exception {
     logger.info("Downloading {} to {}", url, path);
     try (var inputStream = new URL(url).openStream()) {
       var downloadFile = Paths.get(path).toAbsolutePath();
       Files.createDirectories(downloadFile.getParent());
       Files.copy(inputStream, downloadFile, StandardCopyOption.REPLACE_EXISTING);
       logger.info("Finished downloading {} to {}", url, path);
-    } catch (Exception e) {
-      logger.error("Failed downloading {} to {}", url, path);
-      throw new WorkflowException(e);
     }
   }
 }

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/ExecuteCommand.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/ExecuteCommand.java
@@ -14,6 +14,8 @@ package org.apache.baremaps.workflow.tasks;
 
 import org.apache.baremaps.workflow.Task;
 import java.io.IOException;
+
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,14 +24,7 @@ public record ExecuteCommand(String command) implements Task {
   private static final Logger logger = LoggerFactory.getLogger(ExecuteCommand.class);
 
   @Override
-  public void run() {
-    try {
-      new ProcessBuilder().command("/bin/sh", "-c", command).start().waitFor();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    } catch (InterruptedException e) {
-      logger.error("Failed to execute process", e);
-      Thread.currentThread().interrupt();
-    }
+  public void execute(WorkflowContext context) throws Exception {
+    new ProcessBuilder().command("/bin/sh", "-c", command).start().waitFor();
   }
 }

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/ImportGeoPackage.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/ImportGeoPackage.java
@@ -17,6 +17,7 @@ import org.apache.baremaps.postgres.PostgresUtils;
 import org.apache.baremaps.storage.geopackage.GeoPackageDatabase;
 import org.apache.baremaps.storage.postgres.PostgresDatabase;
 import org.apache.baremaps.workflow.Task;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.apache.baremaps.workflow.WorkflowException;
 import java.nio.file.Paths;
 import org.apache.sis.storage.FeatureSet;
@@ -29,14 +30,12 @@ public record ImportGeoPackage(String file, String database, Integer sourceSRID,
   private static final Logger logger = LoggerFactory.getLogger(ImportGeoPackage.class);
 
   @Override
-  public void run() {
+  public void execute(WorkflowContext context) throws Exception {
     logger.info("Importing {} into {}", file, database);
     var path = Paths.get(file).toAbsolutePath();
-    try (
-      var geoPackageStore = new GeoPackageDatabase(path);
-      var dataSource = PostgresUtils.dataSource(database);
-      var postgresDatabase = new PostgresDatabase(dataSource)
-    ) {
+    try (var geoPackageStore = new GeoPackageDatabase(path)) {
+      var dataSource = context.getDataSource(database);
+      var postgresDatabase = new PostgresDatabase(dataSource);
       for (var resource : geoPackageStore.components()) {
         if (resource instanceof FeatureSet featureSet) {
           postgresDatabase.add(new FeatureProjectionTransform(

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/ImportOpenStreetMap.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/ImportOpenStreetMap.java
@@ -23,15 +23,15 @@ import org.apache.baremaps.collection.type.LongListDataType;
 import org.apache.baremaps.collection.type.PairDataType;
 import org.apache.baremaps.collection.utils.FileUtils;
 import org.apache.baremaps.database.ImportService;
-import org.apache.baremaps.database.repository.PostgresHeaderRepository;
-import org.apache.baremaps.database.repository.PostgresNodeRepository;
-import org.apache.baremaps.database.repository.PostgresRelationRepository;
-import org.apache.baremaps.database.repository.PostgresWayRepository;
+import org.apache.baremaps.database.repository.*;
 import org.apache.baremaps.postgres.PostgresUtils;
 import org.apache.baremaps.workflow.Task;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.apache.baremaps.workflow.WorkflowException;
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,61 +41,60 @@ public record ImportOpenStreetMap(String file, String database, Integer database
   private static final Logger logger = LoggerFactory.getLogger(ImportOpenStreetMap.class);
 
   @Override
-  public void run() {
+  public void execute(WorkflowContext context) throws Exception {
     logger.info("Importing {} into {}", file, database);
 
-    try (var dataSource = PostgresUtils.dataSource(database)) {
-      var path = Paths.get(file).toAbsolutePath();
+    var dataSource = context.getDataSource(database);
+    var path = Paths.get(file).toAbsolutePath();
 
-      var headerRepository = new PostgresHeaderRepository(dataSource);
-      var nodeRepository = new PostgresNodeRepository(dataSource);
-      var wayRepository = new PostgresWayRepository(dataSource);
-      var relationRepository = new PostgresRelationRepository(dataSource);
+    var headerRepository = new PostgresHeaderRepository(dataSource);
+    var nodeRepository = new PostgresNodeRepository(dataSource);
+    var wayRepository = new PostgresWayRepository(dataSource);
+    var relationRepository = new PostgresRelationRepository(dataSource);
 
-      headerRepository.drop();
-      nodeRepository.drop();
-      wayRepository.drop();
-      relationRepository.drop();
+    headerRepository.drop();
+    nodeRepository.drop();
+    wayRepository.drop();
+    relationRepository.drop();
 
-      headerRepository.create();
-      nodeRepository.create();
-      wayRepository.create();
-      relationRepository.create();
+    headerRepository.create();
+    nodeRepository.create();
+    wayRepository.create();
+    relationRepository.create();
 
-      var cacheDir = Files.createTempDirectory(Paths.get("."), "cache_");
-      var coordinatesDir = Files.createDirectories(cacheDir.resolve("coordinates"));
-      var referencesKeysDir = Files.createDirectories(cacheDir.resolve("references_keys"));
-      var referencesValuesDir = Files.createDirectories(cacheDir.resolve("references_vals"));
+    var cacheDir = Files.createTempDirectory(Paths.get("."), "cache_");
+    var coordinatesDir = Files.createDirectories(cacheDir.resolve("coordinates"));
+    var referencesKeysDir = Files.createDirectories(cacheDir.resolve("references_keys"));
+    var referencesValuesDir = Files.createDirectories(cacheDir.resolve("references_vals"));
 
-      var coordinates =
-        new LongSizedDataDenseMap<>(
-          new LonLatDataType(), new OnDiskDirectoryMemory(coordinatesDir));
+    var coordinates =
+      new LongSizedDataDenseMap<>(
+        new LonLatDataType(), new OnDiskDirectoryMemory(coordinatesDir));
 
-      var references =
-        new LongDataSortedMap<>(
-          new AlignedDataList<>(
-            new PairDataType<>(new LongDataType(), new LongDataType()),
-            new OnDiskDirectoryMemory(referencesKeysDir)),
-          new DataStore<>(
-            new LongListDataType(), new OnDiskDirectoryMemory(referencesValuesDir)));
+    var references =
+      new LongDataSortedMap<>(
+        new AlignedDataList<>(
+          new PairDataType<>(new LongDataType(), new LongDataType()),
+          new OnDiskDirectoryMemory(referencesKeysDir)
+        ),
+        new DataStore<>(
+          new LongListDataType(), new OnDiskDirectoryMemory(referencesValuesDir))
+      );
 
-      new ImportService(
-        path,
-        coordinates,
-        references,
-        headerRepository,
-        nodeRepository,
-        wayRepository,
-        relationRepository,
-        databaseSrid)
-          .call();
+    new ImportService(
+      path,
+      coordinates,
+      references,
+      headerRepository,
+      nodeRepository,
+      wayRepository,
+      relationRepository,
+      databaseSrid
+    )
+      .call();
 
-      FileUtils.deleteRecursively(cacheDir);
+    FileUtils.deleteRecursively(cacheDir);
 
-      logger.info("Finished importing {} into {}", file, database);
-    } catch (Exception e) {
-      logger.error("Failed importing {} into {}", file, database);
-      throw new WorkflowException(e);
-    }
+    logger.info("Finished importing {} into {}", file, database);
   }
 }

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/ImportShapefile.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/ImportShapefile.java
@@ -17,6 +17,7 @@ import org.apache.baremaps.postgres.PostgresUtils;
 import org.apache.baremaps.storage.postgres.PostgresDatabase;
 import org.apache.baremaps.storage.shapefile.ShapefileFeatureSet;
 import org.apache.baremaps.workflow.Task;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.apache.baremaps.workflow.WorkflowException;
 import java.nio.file.Paths;
 import org.slf4j.Logger;
@@ -28,14 +29,12 @@ public record ImportShapefile(String file, String database, Integer sourceSRID, 
   private static final Logger logger = LoggerFactory.getLogger(ImportShapefile.class);
 
   @Override
-  public void run() {
+  public void execute(WorkflowContext context) throws Exception {
     logger.info("Importing {} into {}", file, database);
     var path = Paths.get(file);
-    try (
-      var featureSet = new ShapefileFeatureSet(path);
-      var dataSource = PostgresUtils.dataSource(database);
-      var postgresDatabase = new PostgresDatabase(dataSource)
-    ) {
+    try (var featureSet = new ShapefileFeatureSet(path)) {
+      var dataSource = context.getDataSource(database);
+      var postgresDatabase = new PostgresDatabase(dataSource);
       postgresDatabase.add(new FeatureProjectionTransform(
         featureSet, new ProjectionTransformer(sourceSRID, targetSRID)));
       logger.info("Finished importing {} into {}", file, database);

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/LogMessage.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/LogMessage.java
@@ -13,6 +13,7 @@
 package org.apache.baremaps.workflow.tasks;
 
 import org.apache.baremaps.workflow.Task;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,7 +22,7 @@ public record LogMessage(String message) implements Task {
   private static final Logger logger = LoggerFactory.getLogger(LogMessage.class);
 
   @Override
-  public void run() {
+  public void execute(WorkflowContext context) throws Exception {
     logger.info(message);
   }
 }

--- a/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/UnzipFile.java
+++ b/baremaps-workflow/src/main/java/org/apache/baremaps/workflow/tasks/UnzipFile.java
@@ -13,6 +13,7 @@
 package org.apache.baremaps.workflow.tasks;
 
 import org.apache.baremaps.workflow.Task;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.apache.baremaps.workflow.WorkflowException;
 import java.io.BufferedInputStream;
 import java.nio.file.Files;
@@ -28,7 +29,7 @@ public record UnzipFile(String file, String directory) implements Task {
   private static final Logger logger = LoggerFactory.getLogger(UnzipFile.class);
 
   @Override
-  public void run() {
+  public void execute(WorkflowContext context) throws Exception {
     logger.info("Unzipping {} to {}", file, directory);
     var filePath = Paths.get(file);
     var directoryPath = Paths.get(directory);

--- a/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/DownloadUrlTest.java
+++ b/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/DownloadUrlTest.java
@@ -15,8 +15,8 @@ package org.apache.baremaps.workflow.tasks;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -24,12 +24,12 @@ class DownloadUrlTest {
 
   @Test
   @Tag("integration")
-  void run() throws IOException {
+  void execute() throws Exception {
     var file = File.createTempFile("test", ".tmp");
     file.deleteOnExit();
     var task = new DownloadUrl("https://raw.githubusercontent.com/baremaps/baremaps/main/README.md",
         file.getAbsolutePath());
-    task.run();
+    task.execute(new WorkflowContext());
     assertTrue(Files.readString(file.toPath()).contains("Baremaps"));
   }
 }

--- a/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ExecuteCommandTest.java
+++ b/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ExecuteCommandTest.java
@@ -14,9 +14,9 @@ package org.apache.baremaps.workflow.tasks;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -24,9 +24,9 @@ class ExecuteCommandTest {
 
   @Test
   @Disabled
-  void run() throws IOException {
+  void execute() throws Exception {
     var path = Paths.get("test.txt").toAbsolutePath();
-    new ExecuteCommand(String.format("echo test > %s", path)).run();
+    new ExecuteCommand(String.format("echo test > %s", path)).execute(new WorkflowContext());
     assertTrue(Files.exists(path));
     assertTrue(Files.readString(path).contains("test"));
     Files.deleteIfExists(path);

--- a/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ExecuteSqlFileTest.java
+++ b/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ExecuteSqlFileTest.java
@@ -16,6 +16,7 @@ package org.apache.baremaps.workflow.tasks;
 
 import org.apache.baremaps.testing.PostgresContainerTest;
 import org.apache.baremaps.testing.TestFiles;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -23,8 +24,8 @@ class ExecuteSqlFileTest extends PostgresContainerTest {
 
   @Test
   @Tag("integration")
-  void run() {
+  void execute() throws Exception {
     var task = new ExecuteSql(jdbcUrl(), TestFiles.resolve("queries.sql").toString(), false);
-    task.run();
+    task.execute(new WorkflowContext());
   }
 }

--- a/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ImportGeoPackageTest.java
+++ b/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ImportGeoPackageTest.java
@@ -16,6 +16,7 @@ package org.apache.baremaps.workflow.tasks;
 
 import org.apache.baremaps.testing.PostgresContainerTest;
 import org.apache.baremaps.testing.TestFiles;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -23,9 +24,9 @@ class ImportGeoPackageTest extends PostgresContainerTest {
 
   @Test
   @Tag("integration")
-  void run() {
+  void execute() throws Exception {
     var task =
         new ImportGeoPackage(TestFiles.resolve("data.gpkg").toString(), jdbcUrl(), 4326, 3857);
-    task.run();
+    task.execute(new WorkflowContext());
   }
 }

--- a/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ImportOpenStreetMapTest.java
+++ b/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ImportOpenStreetMapTest.java
@@ -16,6 +16,7 @@ package org.apache.baremaps.workflow.tasks;
 
 import org.apache.baremaps.testing.PostgresContainerTest;
 import org.apache.baremaps.testing.TestFiles;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -23,9 +24,9 @@ class ImportOpenStreetMapTest extends PostgresContainerTest {
 
   @Test
   @Tag("integration")
-  void run() {
+  void execute() throws Exception {
     var task =
         new ImportOpenStreetMap(TestFiles.resolve("data.osm.pbf").toString(), jdbcUrl(), 3857);
-    task.run();
+    task.execute(new WorkflowContext());
   }
 }

--- a/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ImportShapefileTest.java
+++ b/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/ImportShapefileTest.java
@@ -14,11 +14,11 @@ package org.apache.baremaps.workflow.tasks;
 
 
 
-import java.io.IOException;
 import java.nio.file.Files;
 import org.apache.baremaps.collection.utils.FileUtils;
 import org.apache.baremaps.testing.PostgresContainerTest;
 import org.apache.baremaps.testing.TestFiles;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -26,14 +26,14 @@ class ImportShapefileTest extends PostgresContainerTest {
 
   @Test
   @Tag("integration")
-  void run() throws IOException {
+  void execute() throws Exception {
     var zip = TestFiles.resolve("monaco-shapefile.zip");
     var directory = Files.createTempDirectory("tmp_");
     var unzip = new UnzipFile(zip.toString(), directory.toString());
-    unzip.run();
+    unzip.execute(new WorkflowContext());
     var task = new ImportShapefile(directory.resolve("gis_osm_buildings_a_free_1.shp").toString(),
         jdbcUrl(), 4326, 3857);
-    task.run();
+    task.execute(new WorkflowContext());
     FileUtils.deleteRecursively(directory);
   }
 }

--- a/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/UnzipFileTest.java
+++ b/baremaps-workflow/src/test/java/org/apache/baremaps/workflow/tasks/UnzipFileTest.java
@@ -14,10 +14,10 @@ package org.apache.baremaps.workflow.tasks;
 
 
 
-import java.io.IOException;
 import java.nio.file.Files;
 import org.apache.baremaps.collection.utils.FileUtils;
 import org.apache.baremaps.testing.TestFiles;
+import org.apache.baremaps.workflow.WorkflowContext;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -25,11 +25,11 @@ class UnzipFileTest {
 
   @Test
   @Tag("integration")
-  void run() throws IOException {
+  void execute() throws Exception {
     var zip = TestFiles.resolve("monaco-shapefile.zip");
     var directory = Files.createTempDirectory("tmp_");
     var task = new UnzipFile(zip.toString(), directory.toString());
-    task.run();
+    task.execute(new WorkflowContext());
     FileUtils.deleteRecursively(directory);
   }
 }


### PR DESCRIPTION
Until now workflow tasks were initializing their own datasource, which resulted in a large number of connections to the database. This PR introduce a WorkflowContext aimed at sharing datasources between tasks. In the longer term, the WorkflowContext may be used to keep track of task results.